### PR TITLE
Method Dispatch Annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 cid = { version = "0.8.4", default-features = false }
 fvm_sdk = { version = "1.0.0-rc.1", git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_shared = { version = "0.7.0", git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_shared = { version = "0.8.0", git = "https://github.com/filecoin-project/ref-fvm" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.1"

--- a/fvm_macro_derive/Cargo.toml
+++ b/fvm_macro_derive/Cargo.toml
@@ -14,5 +14,3 @@ fvm_sdk = { version = "1.0.0-rc.1", git = "https://github.com/filecoin-project/r
 fvm_shared = { version = "0.8.0", git = "https://github.com/filecoin-project/ref-fvm" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.1"
-env_logger = "0.9.0"
-log = "0.4.0"

--- a/fvm_macro_derive/Cargo.toml
+++ b/fvm_macro_derive/Cargo.toml
@@ -14,3 +14,5 @@ fvm_sdk = { version = "1.0.0-rc.1", git = "https://github.com/filecoin-project/r
 fvm_shared = { version = "0.8.0", git = "https://github.com/filecoin-project/ref-fvm" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.1"
+env_logger = "0.9.0"
+log = "0.4.0"

--- a/fvm_macro_derive/Cargo.toml
+++ b/fvm_macro_derive/Cargo.toml
@@ -11,6 +11,6 @@ syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0.39"
 fvm_sdk = { version = "1.0.0-rc.1", git = "https://github.com/filecoin-project/ref-fvm" }
-fvm_shared = { version = "0.7.0", git = "https://github.com/filecoin-project/ref-fvm" }
+fvm_shared = { version = "0.8.0", git = "https://github.com/filecoin-project/ref-fvm" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.2.1"

--- a/fvm_macro_derive/src/lib.rs
+++ b/fvm_macro_derive/src/lib.rs
@@ -13,6 +13,17 @@ struct FvmActorMacroAttributes {
   invoke: bool
 }
 
+/// A macro to abort concisely.
+/// This should be part of the SDK as it's very handy.
+macro_rules! abort {
+  ($code:ident, $msg:literal $(, $ex:expr)*) => {
+      fvm_sdk::vm::abort(
+          fvm_shared::error::ExitCode::$code.value(),
+          Some(format!($msg, $($ex,)*).as_str()),
+      )
+  };
+}
+
 #[proc_macro_derive(StateObject)]
 pub fn fvm_state_macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // Construct a representation of Rust code as a syntax tree

--- a/fvm_macro_derive/src/lib.rs
+++ b/fvm_macro_derive/src/lib.rs
@@ -157,11 +157,12 @@ fn match_arm(attr: &ExportAttribute, class_name: &proc_macro2::TokenTree, dispat
 }
 
 fn method_num_dispatch(state_class: String, name: proc_macro2::TokenTree, arms: Vec<proc_macro2::TokenStream>) -> proc_macro2::TokenStream {
+  let class_ident = format_ident!("{}", state_class);
   quote!{
     fn dispatch(id: u32) -> u32 {
       let params = sdk::message::params_raw(id).unwrap().1;
       let params = RawBytes::new(params);
-      let state: #state_class = <#name>::load();
+      let state: #class_ident = <#name>::load();
 
       let ret: Option<RawBytes> = match sdk::message::method_number() {
         #(#arms)*

--- a/fvm_macro_derive/src/lib.rs
+++ b/fvm_macro_derive/src/lib.rs
@@ -156,6 +156,11 @@ fn impl_fvm_actor(macro_attributes: FvmActorMacroAttribute, name: proc_macro2::T
   gen.into()
 }
 
+#[proc_macro_attribute]
+pub fn fvm_export(_attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+  item
+}
+
 fn match_arm(attr: &ExportAttribute, class_name: &proc_macro2::TokenTree, dispatch_type: &String) -> proc_macro2::TokenStream {
   let fn_name = format_ident!("{}", attr.fn_name);
   let lit = match dispatch_type.as_str() {
@@ -314,6 +319,7 @@ fn parse_attributes(attr_string: String) -> FvmActorMacroAttribute {
 
   attrs
 }
+
 fn parse_macro_args(attr_string: String) -> Vec<Vec<String>> {
   attr_string
     .split(",")

--- a/fvm_macro_derive/src/lib.rs
+++ b/fvm_macro_derive/src/lib.rs
@@ -4,8 +4,6 @@ use proc_macro2;
 use quote::{quote, format_ident};
 use syn;
 
-use log::{debug};
-
 struct ParseError;
 
 #[derive(Default, Debug)]
@@ -92,7 +90,6 @@ pub fn fvm_actor(attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -
 }
 
 fn impl_fvm_actor(macro_attributes: FvmActorMacroAttribute, name: proc_macro2::TokenTree, fns: Vec<ExportAttribute>, original_stream: proc_macro2::TokenStream) -> proc_macro::TokenStream {
-  env_logger::init();
   let arms = fns
     .iter()
     .enumerate()
@@ -136,7 +133,7 @@ fn impl_fvm_actor(macro_attributes: FvmActorMacroAttribute, name: proc_macro2::T
     #invoke_block
   };
 
-  debug!("{}", gen.to_string());
+  println!("{}", gen.to_string());
   gen.into()
 }
 

--- a/fvm_macro_derive/src/lib.rs
+++ b/fvm_macro_derive/src/lib.rs
@@ -15,6 +15,7 @@ struct FvmActorMacroAttributes {
 
 /// A macro to abort concisely.
 /// This should be part of the SDK as it's very handy.
+#[macro_export]
 macro_rules! abort {
   ($code:ident, $msg:literal $(, $ex:expr)*) => {
       fvm_sdk::vm::abort(

--- a/fvm_macro_derive/src/lib.rs
+++ b/fvm_macro_derive/src/lib.rs
@@ -4,6 +4,8 @@ use proc_macro2;
 use quote::{quote, format_ident};
 use syn;
 
+use log::{debug};
+
 struct ParseError;
 
 #[derive(Default, Debug)]
@@ -90,6 +92,7 @@ pub fn fvm_actor(attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -
 }
 
 fn impl_fvm_actor(macro_attributes: FvmActorMacroAttribute, name: proc_macro2::TokenTree, fns: Vec<ExportAttribute>, original_stream: proc_macro2::TokenStream) -> proc_macro::TokenStream {
+  env_logger::init();
   let arms = fns
     .iter()
     .enumerate()
@@ -133,7 +136,7 @@ fn impl_fvm_actor(macro_attributes: FvmActorMacroAttribute, name: proc_macro2::T
     #invoke_block
   };
 
-  println!("{}", gen.to_string());
+  debug!("{}", gen.to_string());
   gen.into()
 }
 

--- a/fvm_macro_derive/src/lib.rs
+++ b/fvm_macro_derive/src/lib.rs
@@ -89,7 +89,7 @@ pub fn fvm_actor(attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -
  
   check_impl(&clone);
 
-  let macro_attributes = parse_attributes(attr.to_string());
+  let macro_attributes = build_fvm_actor_attributes(&parse_macro_args(attr.to_string()));
   let (name, fns) = meta(&clone);
 
   impl_fvm_actor(macro_attributes, name, fns, input)
@@ -256,68 +256,6 @@ fn methods(tt: &proc_macro2::TokenTree) -> Vec<ExportAttribute> {
   }
 
   exported
-}
-
-fn extract_pub_fns(tt: &proc_macro2::TokenTree) -> Vec<String> {
-  let mut v: Vec<String> = vec![];
-  let mut current: String = "{}".to_owned();
-  let mut previous: String = "{}".to_owned();
-
-  match tt {
-    proc_macro2::TokenTree::Group(g) => {
-      let gi = g.stream().into_iter();
-      for g in gi {
-        if previous == "pub" && current == "fn" {
-          v.push(extract_identifier(&g));
-        }
-
-        previous = current;
-        current = extract_identifier(&g);
-      }
-    },
-    _ => ()
-  }
-
-  v
-}
-
-fn parse_attributes(attr_string: String) -> FvmActorMacroAttribute {
-  let mut attrs = FvmActorMacroAttribute::default();
-  
-  // invoke by default
-  attrs.invoke = true;
-
-  let vec = attr_string
-    .split(",")
-    .into_iter()
-    .map(|x| x.to_string())
-    .collect::<Vec<String>>()
-    .into_iter()
-    .map(|x: String| x.replace("\"", "")
-      .split(" = ")
-      .into_iter()
-      .map(|x| x.trim().to_string())
-      .collect::<Vec<String>>())
-    .collect::<Vec<Vec<String>>>();
-  
-  for i in vec {
-    match i[0].as_str() {
-      "state" => {
-        attrs.state = i[1].to_string();
-      },
-      "dispatch" => {
-        attrs.dispatch_type = i[1].to_string();
-      },
-      "invoke" => {
-        attrs.invoke = i[1].parse().unwrap_or_default();
-      }
-      _ => {}
-    }
-  }
-
-  println!("{:?}", attrs);
-
-  attrs
 }
 
 fn parse_macro_args(attr_string: String) -> Vec<Vec<String>> {

--- a/fvm_macro_derive/src/lib.rs
+++ b/fvm_macro_derive/src/lib.rs
@@ -13,18 +13,6 @@ struct FvmActorMacroAttributes {
   invoke: bool
 }
 
-/// A macro to abort concisely.
-/// This should be part of the SDK as it's very handy.
-#[macro_export]
-macro_rules! abort {
-  ($code:ident, $msg:literal $(, $ex:expr)*) => {
-      fvm_sdk::vm::abort(
-          fvm_shared::error::ExitCode::$code.value(),
-          Some(format!($msg, $($ex,)*).as_str()),
-      )
-  };
-}
-
 #[proc_macro_derive(StateObject)]
 pub fn fvm_state_macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // Construct a representation of Rust code as a syntax tree

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,15 @@ pub trait StateObject {
   fn load() -> Self;
   fn save(&self) -> Cid;
 }
+
+/// A macro to abort concisely.
+/// This should be part of the SDK as it's very handy.
+#[macro_export]
+macro_rules! abort {
+  ($code:ident, $msg:literal $(, $ex:expr)*) => {
+      fvm_sdk::vm::abort(
+          fvm_shared::error::ExitCode::$code.value(),
+          Some(format!($msg, $($ex,)*).as_str()),
+      )
+  };
+}


### PR DESCRIPTION
## Motivation
Currently, the way to dispatching functions in the FVM is to encode the `method_number` in the message sent to the actor, and retrieve that method using the `sdk::message::method_number` method. This creates a lot of boilerplate code to "wire up" an actors methods to a `method_number`. The initial rough set of macros provided by this package enumerate a class's method names and automatically assign a number. This is very brittle. This PR introduces a new macro `fvm_export` that accepts one parameter, `binding`. When `dispatch="method_num"`, the binding parameter passed to `fvm_export` is interpreted as a number and the dispatch logic is generated accordingly. 
